### PR TITLE
Making the pi-gen project track the Sentry submodule branch of the same

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "stage7/00-rootfs-overlay/Sentry"]
 	path = stage7/00-rootfs-overlay/Sentry
 	url = git@github.com:rfcode/Sentry.git
+    branch = .


### PR DESCRIPTION
name.  This will simplify release process activities.